### PR TITLE
Ignore the whole .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/workspace.xml
-/.idea/libraries
+/.idea
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
I don't know why, but only `/.idea/workspace.xml` and `/.idea/libraries` where in the `.gitignore`.

Because of that I got many files in `.idea` folder that git proposed me to commit. Usually IDE configuration should not be committed in the repository, and the whole `.idea` folder should be ignored.